### PR TITLE
[ECO-784] - Always show 2 decimals for volume values

### DIFF
--- a/components/leaderboard/leaderboard-stats.tsx
+++ b/components/leaderboard/leaderboard-stats.tsx
@@ -34,7 +34,7 @@ const LeaderboardStats = ({
         <Skeleton width={100} />
       ) : (
         `$${totalVolume.toLocaleString(undefined, {
-          minimumFractionDigits: 0,
+          minimumFractionDigits: 2,
           maximumFractionDigits: 2,
         })}`
       ),

--- a/components/leaderboard/user-row.tsx
+++ b/components/leaderboard/user-row.tsx
@@ -75,7 +75,7 @@ const UserRow = ({
         {numberOfTrades.toLocaleString()}
       </td>
       <td className="hidden md:table-cell">
-        {typeof volume === "string" ? volume : (volume / 10 ** 6).toLocaleString(undefined, {minimumFractionDigits:0, maximumFractionDigits: 2})}
+        {typeof volume === "string" ? volume : (volume / 10 ** 6).toLocaleString(undefined, {minimumFractionDigits:2, maximumFractionDigits: 2})}
       </td>
       <td>{points.toLocaleString(undefined, {maximumFractionDigits: 0})}</td>
     </tr>


### PR DESCRIPTION
https://linear.app/econia-labs/issue/ECO-784/always-show-2-decimals-for-volume-even-when-second-digit-is-0