### PR TITLE
[ECO-792] Update queries to combine top 100 and eligible traders

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -6,23 +6,19 @@
 GET /competition_metadata?select=*,volume&id=eq.COMP_ID
 ```
 
-## Eligible traders
+## Eligible traders AND top 100 traders
 
 ```http
-HEAD /competition_leaderboard_users?competition_id=eq.COMP_ID&is_eligible=eq.true
+GET /competition_leaderboard_users?competition_id=eq.COMP_ID&is_eligible=eq.true&limit=100
 Prefer: count=estimated
 ```
 
-The response is in a header named `Content-Range`.
+The body will be a JSON that contains every one of the top 100 users.
+
+The count of eligible traders will be in the response header named `Content-Range` as follows: `Content-Range: 0-X/Y` where X is the number of returned rows - 1, and Y is the total approximated number of eligible traders.
 
 ## User information
 
 ```http
 GET /competition_leaderboard_users?competition_id=eq.COMP_ID&user=eq.ADDR
-```
-
-## Top 100
-
-```http
-GET /competition_leaderboard_users?competition_id=eq.COMP_ID&limit=100
 ```


### PR DESCRIPTION
This PR updates `queries.md` so that it shows how to get both top 100 traders and an estimated count of the total number of eligible traders in only one request.