### PR TITLE
[ECO-810] Use exact instead of estimated count for number of traders

### DIFF
--- a/queries.md
+++ b/queries.md
@@ -10,12 +10,12 @@ GET /competition_metadata?select=*,volume&id=eq.COMP_ID
 
 ```http
 GET /competition_leaderboard_users?competition_id=eq.COMP_ID&is_eligible=eq.true&limit=100
-Prefer: count=estimated
+Prefer: count=exact
 ```
 
 The body will be a JSON that contains every one of the top 100 users.
 
-The count of eligible traders will be in the response header named `Content-Range` as follows: `Content-Range: 0-X/Y` where X is the number of returned rows - 1, and Y is the total approximated number of eligible traders.
+The count of eligible traders will be in the response header named `Content-Range` as follows: `Content-Range: 0-X/Y` where X is the number of returned rows - 1, and Y is the total number of eligible traders.
 
 ## User information
 

--- a/services/leaderboard.service.ts
+++ b/services/leaderboard.service.ts
@@ -6,7 +6,7 @@ const COMP_ID = process.env.NEXT_PUBLIC_COMPETITION_ID;
 const LEADERBOARD_MAX_ROWS = process.env.NEXT_PUBLIC_LEADERBOARD_MAX_ROWS;
 
 export const getLeaderboard = async (): Promise<AxiosResponse<leaderboardType[]>> => {
-  const headers = { Prefer: 'count=estimated' };
+  const headers = { Prefer: 'count=exact' };
   const rs = await getRequest(`competition_leaderboard_users?competition_id=eq.${COMP_ID}&is_eligible=eq.true&limit=${LEADERBOARD_MAX_ROWS}`, headers);
   return rs;
 };


### PR DESCRIPTION
The estimated count can be up to 25% off, as demonstrated offline in curl requests.

Use exact count for number of traders.

https://postgrest.org/en/stable/references/api/tables_views.html?highlight=count#exact-count